### PR TITLE
Fix Booking Dashboard label typos

### DIFF
--- a/hotel_reservation_dashboard/security/hotel_management_odoo_groups.xml
+++ b/hotel_reservation_dashboard/security/hotel_management_odoo_groups.xml
@@ -2,11 +2,11 @@
 <odoo>
 
     <record id="booking_edit_dashboard_access" model="res.groups">
-        <field name="name">Booking Dasboard Edit Accesr</field>
+        <field name="name">Booking Dashboard Edit Access</field>
         <field name="category_id" ref="hotel_management_odoo.module_category_hotel_management"/>
     </record>
     <record id="booking_dashboard_access" model="res.groups">
-        <field name="name">Booking Dasboard</field>
+        <field name="name">Booking Dashboard</field>
         <field name="category_id" ref="hotel_management_odoo.module_category_hotel_management"/>
     </record>
 

--- a/hotel_reservation_dashboard/views/dsm_menu.xml
+++ b/hotel_reservation_dashboard/views/dsm_menu.xml
@@ -23,11 +23,11 @@
     </record>
 
     <record id="booking_edit_dashboard_access" model="res.groups">
-        <field name="name">Booking Dasboard Edit Access</field>
+        <field name="name">Booking Dashboard Edit Access</field>
         <field name="category_id" ref="hotel_management_odoo.module_category_hotel_management"/>
     </record>
     <record id="booking_dashboard_access" model="res.groups">
-        <field name="name">Booking Dasboard</field>
+        <field name="name">Booking Dashboard</field>
         <field name="category_id" ref="hotel_management_odoo.module_category_hotel_management"/>
     </record>
 


### PR DESCRIPTION
## Summary
- correct typos in booking dashboard group names

## Testing
- `python3 -m py_compile`

------
https://chatgpt.com/codex/tasks/task_b_6855abe3a2048322b21c4df7c6af19fd