### PR TITLE
Fix manifest duplicate entry

### DIFF
--- a/hotel_reservation_dashboard/__manifest__.py
+++ b/hotel_reservation_dashboard/__manifest__.py
@@ -27,5 +27,4 @@
     'auto_install': False,
     'license': 'AGPL-3',
     'images': ['static/description/assets/screenshots/banner.png'],
-    'application': True,
 }


### PR DESCRIPTION
## Summary
- remove duplicate 'application' flag from hotel_reservation_dashboard manifest

## Testing
- `python -m py_compile hotel_reservation_dashboard/__manifest__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855abfcb498832299d76dacb13d5802